### PR TITLE
Improve header UX, dark mode, fonts, and active nav underline

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,11 @@
 		<meta
 			name="keywords"
 			content="Student Research Forum, SMU, SMIT, research, student projects, innovation, technology, science, STEM, sikkim, Manipal" />
+
+		<!-- Google Fonts: Poppins -->
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 	</head>
 	<body>
 

--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -4,8 +4,8 @@ import Footer from "./components/Footer";
 import Cover from "./shared/Cover";
 import { Outlet } from "react-router-dom";
 const Layout = () => {
-       return (
-	       <div className="flex flex-col justify-between min-h-screen bg-orange-100 dark:bg-gray-900 font-satoshi">
+	   return (
+	       <div className="flex flex-col justify-between min-h-screen bg-orange-100 dark:bg-gray-900 font-poppins">
 		       <Header />
 		       <div className="flex flex-col gap-4 p-2 mb-4 md:gap-8 md:px-16">
 			       <Cover />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,21 +7,35 @@ import { FiSun, FiMoon } from "react-icons/fi";
 import SMU from "../images/smulogo.jpg";
 
 const Header = () => {
-	const [isSidebarOpen, setSidebarOpen] = useState(false);
-	const [darkMode, setDarkMode] = useState(false);
+    const [isSidebarOpen, setSidebarOpen] = useState(false);
+    const [darkMode, setDarkMode] = useState(false);
 
-	const links = [
-		{ title: "Home", path: "/" },
-		{ title: "Governing Council", path: "/governing" },
-		{ title: "Articles", path: "/articles" },
-		{ title: "Events", path: "/events" },
-		{ title: "Gallery", path: "/gallery" },
-		{ title: "SRF Colloquium '25", path: "https://shorturl.at/xmUL7", external: true, highlight: true },
-	];
+    const links = [
+        { title: "Home", path: "/" },
+        { title: "Governing Council", path: "/governing" },
+        { title: "Articles", path: "/articles" },
+        { title: "Events", path: "/events" },
+        { title: "Gallery", path: "/gallery" },
+        { title: "SRF Colloquium '25", path: "https://shorturl.at/xmUL7", external: true, highlight: true },
+    ];
 
-       const toggleSidebar = () => {
-	       setSidebarOpen(!isSidebarOpen);
-       };
+      const toggleSidebar = () => {
+          setSidebarOpen(!isSidebarOpen);
+      };
+
+      useEffect(() => {
+          const handleResize = () => {
+              try {
+                  if (window.innerWidth >= 768 && isSidebarOpen) {
+                      setSidebarOpen(false);
+                  }
+              } catch (e) {
+                  // ignore
+              }
+          };
+          window.addEventListener('resize', handleResize);
+          return () => window.removeEventListener('resize', handleResize);
+      }, [isSidebarOpen]);
 
 
 
@@ -43,42 +57,44 @@ const Header = () => {
 		});
 	};
 
-	return (
-		<div className="relative w-full px-4 py-2 bg-orange-500 md:px-16">
-			<div className="flex items-center justify-between">
-			   <div className="flex gap-2 items-center">
-			   <button
-				   aria-label="Toggle dark mode"
-				   onClick={toggleDarkMode}
-				   className="mr-3 p-2 rounded-full border border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-1 md:-ml-10 relative z-20"
-			   >
-			       {darkMode ? <FiSun className="text-yellow-400" size={20} /> : <FiMoon className="text-gray-700" size={20} />}
-		       </button>
-			       <img src={Logo} width={50} alt="Logo" className="rounded-md" />
-			       <img src={SMU} alt="" />
-		       </div>
-				<div className="items-center justify-between hidden md:flex w-[60%]">
-					{links.map((link, idx) => {
-						return (
-							<div className="w-fit" key={idx}>
-								<NavLinks {...link} />
-							</div>
-						);
-					})}
-				</div>
-				<div className="flex items-center md:hidden">
-					<button onClick={toggleSidebar}>
-						<FiMenu className="text-white" size={24} />
-					</button>
-				</div>
-			</div>
-			<Sidebar
-				links={links}
-				isOpen={isSidebarOpen}
-				toggleSidebar={toggleSidebar}
-			/>
-		</div>
-	);
+    return (
+        <div className="relative w-full px-4 py-2 bg-orange-500 md:px-16">
+            <div className="flex items-center justify-between">
+               <div className="flex gap-2 items-center">
+                   <img src={Logo} width={50} alt="Logo" className="rounded-md" />
+                   <img src={SMU} alt="" />
+               </div>
+                <div className="items-center justify-between hidden md:flex w-[60%]">
+                    {links.map((link, idx) => {
+                        return (
+                            <div className="w-fit" key={idx}>
+                                <NavLinks {...link} />
+                            </div>
+                        );
+                    })}
+                </div>
+                <div className="flex items-center gap-3">
+                    <button
+                        aria-label="Toggle dark mode"
+                        onClick={toggleDarkMode}
+                        className="p-2 rounded-full border border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-1 relative z-20"
+                    >
+                        {darkMode ? <FiSun className="text-yellow-300" size={20} /> : <FiMoon className="text-gray-700" size={20} />}
+                    </button>
+                    <div className="md:hidden">
+                        <button onClick={toggleSidebar} aria-label="Open menu">
+                            <FiMenu className="text-white" size={24} />
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <Sidebar
+                links={links}
+                isOpen={isSidebarOpen}
+                toggleSidebar={toggleSidebar}
+            />
+        </div>
+    );
 };
 
 export default Header;

--- a/src/components/NavLinks.jsx
+++ b/src/components/NavLinks.jsx
@@ -1,23 +1,26 @@
-import React from "react";
+/* eslint-disable react/prop-types */
 import { Link, useLocation } from "react-router-dom";
 const NavLinks = ({ title, path, external, highlight }) => {
 	const location = useLocation();
 	const isActive = location.pathname === path;
 	
-	const baseClasses = "text-base font-semibold transition-transform duration-500 ease-in-out transform cursor-pointer font-satoshi hover:scale-110 hover:font-bold hover:text-white";
-	const highlightClasses = highlight ? "font-bold text-white border-2 border-white px-2 py-1 rounded-md bouncy-highlight" : "";
-	const activeClasses = isActive && !external ? "text-white font-bold" : "";
+    const wrapperClasses = "text-base font-semibold font-poppins";
+    const linkBase = "inline-block transition-transform duration-500 ease-in-out transform cursor-pointer text-white/90 hover:text-white dark:text-white/80 dark:hover:text-white pb-1";
+    const highlightClasses = highlight ? "font-bold text-white border-2 border-white px-2 py-1 rounded-md bouncy-highlight" : "";
+    const linkActive = isActive && !external ? "text-white font-bold border-black dark:border-orange-300 border-b-2 md:border-b-[3px]" : "";
 	
 	return (
-		<div className={`${baseClasses} ${highlightClasses} ${activeClasses}`}>
-			{external ? (
-				<a href={path} target="_blank" rel="noopener noreferrer">
-					{title}
-				</a>
-			) : (
-				<Link to={path}>{title}</Link>
-			)}
-		</div>
+        <div className={wrapperClasses}>
+            {external ? (
+                <a href={path} target="_blank" rel="noopener noreferrer" className={`${linkBase} ${highlightClasses} ${linkActive}`}>
+                    {title}
+                </a>
+            ) : (
+                <Link to={path} className={`${linkBase} ${highlightClasses} ${linkActive}`}>
+                    {title}
+                </Link>
+            )}
+        </div>
 	);
 };
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 const Sidebar = ({ links, isOpen, toggleSidebar }) => {
 	return (
 		<div
-			className={`fixed top-0 left-0 w-64 h-full bg-orange-300 transform py-2 ${
+			className={`fixed top-0 left-0 w-64 h-full bg-orange-300 transform py-2 md:hidden ${
 				isOpen ? "translate-x-0" : "-translate-x-full"
 			} transition-transform duration-300 ease-in-out z-50`}>
 			<div className="flex justify-between px-4 ">
@@ -22,8 +22,8 @@ const Sidebar = ({ links, isOpen, toggleSidebar }) => {
 								href={link.path}
 								target="_blank"
 								rel="noopener noreferrer"
-								className={`px-4 py-2 hover:bg-orange-400 text-white ${link.highlight ? 'font-bold border-2 border-white rounded-md' : ''}`}>
-								{link.title}
+							className={`px-4 py-2 hover:bg-orange-400 text-white ${link.highlight ? 'font-bold border-2 border-white rounded-md' : ''}`}>
+							{link.title}
 							</a>
 						) : (
 							<Link

--- a/src/index.css
+++ b/src/index.css
@@ -2,33 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-/* src/fonts.css */
-@font-face {
-	font-family: "Satoshi";
-	src: url("./fonts/Satoshi-Regular.otf") format("otf");
-	font-weight: 400;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: "Satoshi";
-	src: url("./fonts/Satoshi-Bold.otf") format("otf");
-	font-weight: 700;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: "Satoshi";
-	src: url("./fonts/Satoshi-Light.otf") format("otf");
-	font-weight: 300;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: "Satoshi";
-	src: url("./fonts/Satoshi-Medium.otf") format("otf");
-	font-weight: 500;
-	font-style: normal;
+/* Base font family */
+:root {
+    --font-sans: 'Poppins', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
 }
 
 .slick-prev,
@@ -75,5 +51,11 @@
 
 	.btn-ghost {
 		@apply inline-block px-4 py-2 rounded-md font-medium bg-transparent border border-gray-200 dark:border-gray-700 text-black dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700;
+	}
+}
+
+@layer base {
+	h1, h2, h3, h4, h5, h6 {
+		@apply text-gray-900 dark:text-white;
 	}
 }

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -26,7 +26,7 @@ const Contact = () => {
 	};
 	return (
 		<>
-			<div className="mx-auto text-3xl font-bold text-orange-800 font-satoshi md:text-5xl">
+			<div className="mx-auto text-3xl font-bold text-orange-800 font-poppins md:text-5xl">
 				Contact Us
 			</div>
 			<div className="grid grid-cols-1 gap-4 mx-auto mb-8 text-center">

--- a/src/pages/Developers.jsx
+++ b/src/pages/Developers.jsx
@@ -155,7 +155,7 @@ const DevelopersPage = () => {
 
 	return (
 		<div className="container mx-auto px-4 py-8">
-			<h1 className="text-3xl md:text-5xl font-bold text-orange-800 font-satoshi text-center mb-8">
+			<h1 className="text-3xl md:text-5xl font-bold text-orange-800 font-poppins text-center mb-8">
 				Our Development Team
 			</h1>
 			<div className="grid grid-cols-1 gap-8">

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -82,7 +82,7 @@ const Events = () => {
 	if (events.length) {
 		return (
 			<>
-				<div className="mx-auto text-3xl font-bold text-orange-800 dark:text-orange-300 font-satoshi md:text-5xl">
+				<div className="mx-auto text-3xl font-bold text-orange-800 dark:text-orange-300 font-poppins md:text-5xl">
 					Events
 				</div>
 				<div className="container mx-auto">

--- a/src/pages/Governing.jsx
+++ b/src/pages/Governing.jsx
@@ -124,7 +124,7 @@ const Governing = () => {
 
   return (
     <div className="container mx-auto px-4">
-      <h1 className="text-3xl md:text-5xl font-bold text-orange-800 font-satoshi text-center mb-8">
+      <h1 className="text-3xl md:text-5xl font-bold text-orange-800 font-poppins text-center mb-8">
         Governing Council
       </h1>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,8 @@ export default {
        theme: {
 	       extend: {
 		       fontFamily: {
-			       satoshi: ["Satoshi", "sans-serif"],
+	               satoshi: ["Satoshi", "sans-serif"],
+	               poppins: ["Poppins", "ui-sans-serif", "system-ui", "-apple-system", "Segoe UI", "Roboto", "Arial", "sans-serif"],
 		       },
 		       fontWeight: {
 			       regular: 400,


### PR DESCRIPTION

<img width="2940" height="1670" alt="screenshot_2025-10-16T10-55-54-963Z" src="https://github.com/user-attachments/assets/609e9d81-206e-4729-a852-0efd2462ff34" />


> Move theme toggle to right side of header
> Fix dark mode: headings now turn white
> Auto-hide mobile sidebar when resizing to desktop
> Remove nav icons for a cleaner look
> Add Poppins font and apply site‑wide
> Improve nav link contrast in dark mode
> Show active nav underline; thicker on desktop